### PR TITLE
Create class Test_sign_normalize in test_misc_transformations.py

### DIFF
--- a/core/signal_processing/misc_transformations.py
+++ b/core/signal_processing/misc_transformations.py
@@ -193,7 +193,6 @@ def skip_apply_func(
     return df
 
 
-# TODO(Paul): Add test coverage.
 def sign_normalize(
     signal: Union[pd.DataFrame, pd.Series],
     atol: float = 0,

--- a/core/signal_processing/test/test_misc_transformations.py
+++ b/core/signal_processing/test/test_misc_transformations.py
@@ -10,6 +10,7 @@ import helpers.hunit_test as hunitest
 
 _LOG = logging.getLogger(__name__)
 
+
 class Test_sign_normalize(hunitest.TestCase):
     """
     Check that signal values are normalized according to sign correctly.

--- a/core/signal_processing/test/test_misc_transformations.py
+++ b/core/signal_processing/test/test_misc_transformations.py
@@ -10,6 +10,69 @@ import helpers.hunit_test as hunitest
 
 _LOG = logging.getLogger(__name__)
 
+class Test_sign_normalize(hunitest.TestCase):
+    """
+    Check that signal values are normalized according to sign correctly.
+    """
+
+    def test1(self) -> None:
+        """
+        - input signal is `pd.Series`
+        - atol = 0
+        """
+        signal = pd.Series([-5, -1, 0, 1, 5])
+        res = csprmitr.sign_normalize(signal)
+        actual_signature = hpandas.df_to_str(res)
+        expected_signature = r"""
+           0
+        0 -1
+        1 -1
+        2  0
+        3  1
+        4  1
+        """
+        self.assert_equal(actual_signature, expected_signature, fuzzy_match=True)
+
+    def test2(self) -> None:
+        """
+        - input signal is `pd.Series`
+        - atol = 2
+        """
+        signal = pd.Series([-3, -2, 0, 2, 3])
+        atol = 2
+        res = csprmitr.sign_normalize(signal, atol)
+        actual_signature = hpandas.df_to_str(res)
+        expected_signature = r"""
+           0
+        0 -1
+        1 -1
+        2  0
+        3  1
+        4  1
+        """
+        self.assert_equal(actual_signature, expected_signature, fuzzy_match=True)
+
+    def test3(self) -> None:
+        """
+        - input signal is `pd.DataFrame`
+        - atol = 0
+        """
+        signal = pd.DataFrame([-5, -1, 0, 1, 5])
+        actual = csprmitr.sign_normalize(signal)
+        expected = pd.DataFrame([-1, -1, 0, 1, 1])
+        self.assertTrue(actual.equals(expected))
+
+    def test4(self) -> None:
+        """
+        - input signal is `pd.DataFrame`
+        - atol = 2
+        """
+        signal = pd.DataFrame([-3, -2, 0, 2, 3])
+        atol = 2
+        actual = csprmitr.sign_normalize(signal, atol)
+        expected = pd.DataFrame([-1, -1, 0, 1, 1])
+        self.assertTrue(actual.equals(expected))
+
 
 class Test_get_symmetric_equisized_bins(hunitest.TestCase):
     def test_zero_in_bin_interior_false(self) -> None:


### PR DESCRIPTION
#784 Create `class Test_sign_normalize` in `test_misc_transformations.py` to test `sign_normalize()`

When run linter `invoke lint --files "./core/signal_processing/test/test_misc_transformations.py"`
it raises following error:
```AssertionError: 
################################################################################
* Failed assertion *
'kaizen-ai/kaizenflow' in '{'alphamatic/amp': 'amp', 'sorrentum/dev_tools': 'dev_tools', 'sorrentum/sorrentum': 'sorr'}'
Invalid name='kaizen-ai/kaizenflow' for in_mode='full_name'
################################################################################```