### PR TITLE
SorrTask-891 Unit tests for compute epoch function

### DIFF
--- a/core/finance/prediction_processing.py
+++ b/core/finance/prediction_processing.py
@@ -37,7 +37,6 @@ def compute_bar_start_timestamps(
     return srs
 
 
-# TODO(Paul): Add unit tests.
 def compute_epoch(
     data: Union[pd.Series, pd.DataFrame], *, unit: Optional[str] = None
 ) -> Union[pd.Series, pd.DataFrame]:

--- a/core/finance/test/test_prediction_processing.py
+++ b/core/finance/test/test_prediction_processing.py
@@ -68,33 +68,23 @@ class TestComputeEpoch(hunitest.TestCase):
     Test the computation of epoch time series with different units.
     """
 
-    def get_series_input(self) -> pd.Series:
+    def helper(self) -> pd.Series:
         """
-        Fetch series input data for test.
+        Fetch input data for test.
         """
         timestamp_index = pd.date_range("2024-01-01", periods=10, freq="T")
         close = list(range(200, 210))
-        data = {"timestamp": timestamp_index, "close": close}
-        srs = pd.Series(data, timestamp_index)
+        data = {"close": close}
+        srs = pd.Series(data=data, index=timestamp_index)
         return srs
-
-    def get_dataframe_input(self) -> pd.DataFrame:
-        """
-        Fetch dataframe input data for test.
-        """
-        timestamp_index = pd.date_range("2024-01-01", periods=10, freq="T")
-        volume = list(range(40, 50))
-        data = {"timestamp": timestamp_index, "volume": volume}
-        df = pd.DataFrame(data=data).set_index("timestamp")
-        return df
 
     def test1(self) -> None:
         """
-        Test series input data with unit - minute.
+        Check that epoch is computed correctly for minute unit.
         """
         unit = "minute"
-        srs = self.get_series_input()
-        result_srs = cfiprpro.compute_epoch(srs, unit=unit)
+        srs = self.helper()
+        result = cfiprpro.compute_epoch(srs, unit=unit)
         # Define expected values.
         expected_length = 10
         expected_column_value = None
@@ -113,16 +103,16 @@ class TestComputeEpoch(hunitest.TestCase):
         """
         # Check signature.
         self.check_srs_output(
-            result_srs, expected_length, expected_column_value, expected_signature
+            result, expected_length, expected_column_value, expected_signature
         )
 
     def test2(self) -> None:
         """
-        Test series input data with unit - second.
+        Check that epoch is computed correctly for second unit.
         """
         unit = "second"
-        srs = self.get_series_input()
-        result_srs = cfiprpro.compute_epoch(srs, unit=unit)
+        srs = self.helper()
+        result = cfiprpro.compute_epoch(srs, unit=unit)
         # Define expected values.
         expected_length = 10
         expected_column_value = None
@@ -141,16 +131,16 @@ class TestComputeEpoch(hunitest.TestCase):
         """
         # Check signature.
         self.check_srs_output(
-            result_srs, expected_length, expected_column_value, expected_signature
+            result, expected_length, expected_column_value, expected_signature
         )
 
     def test3(self) -> None:
         """
-        Test series input data with unit - nanosecond.
+        Check that epoch is computed correctly for nanosecond unit.
         """
         unit = "nanosecond"
-        srs = self.get_series_input()
-        result_srs = cfiprpro.compute_epoch(srs, unit=unit)
+        srs = self.helper()
+        result = cfiprpro.compute_epoch(srs, unit=unit)
         # Define expected values.
         expected_length = 10
         expected_column_value = None
@@ -169,16 +159,18 @@ class TestComputeEpoch(hunitest.TestCase):
         """
         # Check signature.
         self.check_srs_output(
-            result_srs, expected_length, expected_column_value, expected_signature
+            result, expected_length, expected_column_value, expected_signature
         )
 
     def test4(self) -> None:
         """
-        Test dataframe input data with any unit.
+        Check that epoch is computed correctly for dataframe input.
         """
-        df = self.get_dataframe_input()
-        # Testing df input with default unit - minute.
-        result_df = cfiprpro.compute_epoch(df)
+        srs = self.helper()
+        # Convert series data to dataframe
+        df = srs.to_frame()
+        # Testing input with default unit - minute.
+        result = cfiprpro.compute_epoch(df)
         # Define expected values.
         expected_length = 10
         expected_column_value = None
@@ -188,7 +180,6 @@ class TestComputeEpoch(hunitest.TestCase):
         columns=minute
         shape=(10, 1)
                                 minute
-                  timestamp
         2024-01-01 00:00:00        28401120
         2024-01-01 00:01:00        28401121
         2024-01-01 00:02:00        28401122
@@ -199,7 +190,7 @@ class TestComputeEpoch(hunitest.TestCase):
         """
         # Check signature.
         self.check_df_output(
-            result_df,
+            result,
             expected_length,
             expected_column_value,
             expected_column_value,

--- a/core/finance/test/test_prediction_processing.py
+++ b/core/finance/test/test_prediction_processing.py
@@ -58,3 +58,42 @@ datetime,MN0,MN1,MN0,MN1,MN0,MN1,MN0,MN1
         )
         df.index.freq = "T"
         return df
+
+
+# ########################################################################
+
+
+class TestComputeEpoch(hunitest.TestCase):
+    """
+    Test the computation of epoch time series with different units.
+    """
+
+    def get_series_data(self):
+        """
+        Generate series input data for test.
+        """
+
+    def get_dataframe_data(self):
+        """
+        Generateb dataframe input data for test.
+        """
+
+    def test1(self):
+        """
+        Test series input data with unit - minutes.
+        """
+
+    def test2(self):
+        """
+        Test series input data with unit - seconds.
+        """
+
+    def test3(self):
+        """
+        Test series input data with unit - nanoseconds.
+        """
+
+    def test4(self):
+        """
+        Test dataframe input data with any unit.
+        """

--- a/core/finance/test/test_prediction_processing.py
+++ b/core/finance/test/test_prediction_processing.py
@@ -123,7 +123,7 @@ class TestComputeEpoch(hunitest.TestCase):
         unit = "second"
         srs = self.get_series_input()
         result_srs = cfiprpro.compute_epoch(srs, unit=unit)
-        # Define expected values
+        # Define expected values.
         expected_length = 10
         expected_column_value = None
         expected_signature = r"""
@@ -151,7 +151,7 @@ class TestComputeEpoch(hunitest.TestCase):
         unit = "nanosecond"
         srs = self.get_series_input()
         result_srs = cfiprpro.compute_epoch(srs, unit=unit)
-        # Define expected values
+        # Define expected values.
         expected_length = 10
         expected_column_value = None
         expected_signature = r"""

--- a/core/finance/test/test_prediction_processing.py
+++ b/core/finance/test/test_prediction_processing.py
@@ -167,9 +167,7 @@ class TestComputeEpoch(hunitest.TestCase):
         Check that epoch is computed correctly for dataframe input.
         """
         srs = self.helper()
-        # Convert series data to dataframe
         df = srs.to_frame()
-        # Testing input with default unit - minute.
         result = cfiprpro.compute_epoch(df)
         # Define expected values.
         expected_length = 10

--- a/core/finance/test/test_prediction_processing.py
+++ b/core/finance/test/test_prediction_processing.py
@@ -60,7 +60,7 @@ datetime,MN0,MN1,MN0,MN1,MN0,MN1,MN0,MN1
         return df
 
 
-# ########################################################################
+# #############################################################################
 
 
 class TestComputeEpoch(hunitest.TestCase):
@@ -68,32 +68,106 @@ class TestComputeEpoch(hunitest.TestCase):
     Test the computation of epoch time series with different units.
     """
 
-    def get_series_data(self):
+    def get_series_input(self) -> pd.Series:
         """
         Generate series input data for test.
         """
+        timestamp_index = pd.date_range("2024-01-01", periods=10, freq="T")
+        close = list(range(200, 210))
+        data = {"timestamp": timestamp_index, "close": close}
+        srs = pd.Series(data, timestamp_index)
+        return srs
 
-    def get_dataframe_data(self):
+    def get_dataframe_input(self) -> pd.DataFrame:
         """
-        Generateb dataframe input data for test.
-        """
-
-    def test1(self):
-        """
-        Test series input data with unit - minutes.
-        """
-
-    def test2(self):
-        """
-        Test series input data with unit - seconds.
+        Generate dataframe input data for test.
         """
 
-    def test3(self):
+    def test1(self) -> None:
         """
-        Test series input data with unit - nanoseconds.
+        Test series input data with unit - minute.
         """
+        unit = "minute"
+        srs = self.get_series_input()
+        result_srs = cfiprpro.compute_epoch(srs, unit=unit)
+        # Define expected values.
+        expected_length = 10
+        expected_column_value = None
+        expected_signature = r"""
+                              minute
+        2024-01-01 00:00:00    28401120
+        2024-01-01 00:01:00    28401121
+        2024-01-01 00:02:00    28401122
+        2024-01-01 00:03:00    28401123
+        2024-01-01 00:04:00    28401124
+        2024-01-01 00:05:00    28401125
+        2024-01-01 00:06:00    28401126
+        2024-01-01 00:07:00    28401127
+        2024-01-01 00:08:00    28401128
+        2024-01-01 00:09:00    28401129
+        """
+        # Check signature.
+        self.check_srs_output(
+            result_srs, expected_length, expected_column_value, expected_signature
+        )
 
-    def test4(self):
+    def test2(self) -> None:
+        """
+        Test series input data with unit - second.
+        """
+        unit = "second"
+        srs = self.get_series_input()
+        result_srs = cfiprpro.compute_epoch(srs, unit=unit)
+        # Define expected values
+        expected_length = 10
+        expected_column_value = None
+        expected_signature = r"""
+                                second
+        2024-01-01 00:00:00    1704067200
+        2024-01-01 00:01:00    1704067260
+        2024-01-01 00:02:00    1704067320
+        2024-01-01 00:03:00    1704067380
+        2024-01-01 00:04:00    1704067440
+        2024-01-01 00:05:00    1704067500
+        2024-01-01 00:06:00    1704067560
+        2024-01-01 00:07:00    1704067620
+        2024-01-01 00:08:00    1704067680
+        2024-01-01 00:09:00    1704067740
+        """
+        # Check signature.
+        self.check_srs_output(
+            result_srs, expected_length, expected_column_value, expected_signature
+        )
+
+    def test3(self) -> None:
+        """
+        Test series input data with unit - nanosecond.
+        """
+        unit = "nanosecond"
+        srs = self.get_series_input()
+        result_srs = cfiprpro.compute_epoch(srs, unit=unit)
+        # Define expected values
+        expected_length = 10
+        expected_column_value = None
+        expected_signature = r"""
+                                     nanosecond
+        2024-01-01 00:00:00    1704067200000000000
+        2024-01-01 00:01:00    1704067260000000000
+        2024-01-01 00:02:00    1704067320000000000
+        2024-01-01 00:03:00    1704067380000000000
+        2024-01-01 00:04:00    1704067440000000000
+        2024-01-01 00:05:00    1704067500000000000
+        2024-01-01 00:06:00    1704067560000000000
+        2024-01-01 00:07:00    1704067620000000000
+        2024-01-01 00:08:00    1704067680000000000
+        2024-01-01 00:09:00    1704067740000000000
+        """
+        # Check signature.
+        self.check_srs_output(
+            result_srs, expected_length, expected_column_value, expected_signature
+        )
+
+    def test4(self) -> None:
         """
         Test dataframe input data with any unit.
         """

--- a/core/finance/test/test_prediction_processing.py
+++ b/core/finance/test/test_prediction_processing.py
@@ -70,7 +70,7 @@ class TestComputeEpoch(hunitest.TestCase):
 
     def get_series_input(self) -> pd.Series:
         """
-        Generate series input data for test.
+        Fetch series input data for test.
         """
         timestamp_index = pd.date_range("2024-01-01", periods=10, freq="T")
         close = list(range(200, 210))
@@ -80,8 +80,13 @@ class TestComputeEpoch(hunitest.TestCase):
 
     def get_dataframe_input(self) -> pd.DataFrame:
         """
-        Generate dataframe input data for test.
+        Fetch dataframe input data for test.
         """
+        timestamp_index = pd.date_range("2024-01-01", periods=10, freq="T")
+        volume = list(range(40, 50))
+        data = {"timestamp": timestamp_index, "volume": volume}
+        df = pd.DataFrame(data=data).set_index("timestamp")
+        return df
 
     def test1(self) -> None:
         """
@@ -171,3 +176,32 @@ class TestComputeEpoch(hunitest.TestCase):
         """
         Test dataframe input data with any unit.
         """
+        df = self.get_dataframe_input()
+        # Testing df input with default unit - minute.
+        result_df = cfiprpro.compute_epoch(df)
+        # Define expected values.
+        expected_length = 10
+        expected_column_value = None
+        expected_signature = r"""
+        # df=
+        index=[2024-01-01 00:00:00, 2024-01-01 00:09:00]
+        columns=minute
+        shape=(10, 1)
+                                minute
+                  timestamp
+        2024-01-01 00:00:00        28401120
+        2024-01-01 00:01:00        28401121
+        2024-01-01 00:02:00        28401122
+                                 ...
+        2024-01-01 00:07:00        28401127
+        2024-01-01 00:08:00        28401128
+        2024-01-01 00:09:00        28401129
+        """
+        # Check signature.
+        self.check_df_output(
+            result_df,
+            expected_length,
+            expected_column_value,
+            expected_column_value,
+            expected_signature,
+        )


### PR DESCRIPTION
Task [#891](https://github.com/kaizen-ai/kaizenflow/issues/891)

- Added unit tests for compute_epoch function:-
   -> Function for fetching test data, one each for series and dataframe
   -> 3 Unit Tests, one for each available unit value for Series input
   -> Unit test with dataframe input