### PR TITLE
SorrTask1037_Unit_test_calculate_limit_price

### DIFF
--- a/oms/limit_price_computer/test/test_limit_price_computer_using_spread.py
+++ b/oms/limit_price_computer/test/test_limit_price_computer_using_spread.py
@@ -87,6 +87,41 @@ class Test_limit_price_computer_using_spread(hunitest.TestCase):
         """
         self.assert_equal(actual_str, expected_str, fuzzy_match=True)
 
+    def test_invalid_side1(self) -> None:
+        """
+        Check that an assertion is raised when a non-existent side value is
+        supplied.
+        """
+        with self.assertRaises(ValueError) as cm:
+            self._calculate_price_helper(
+                "non-existent-side", 0.5, 0.01, 1464553467, 3, 0
+            )
+        act = str(cm.exception)
+        exp = r"Invalid side='non-existent-side'"
+        self.assert_equal(act, exp, fuzzy_match=True)
+
+    def test_invalid_side2(self) -> None:
+        """
+        Check that an assertion is raised when a side value is supplied in the
+        wrong case.
+        """
+        with self.assertRaises(ValueError) as cm:
+            self._calculate_price_helper("BUY", 0.5, 0.01, 1464553467, 3, 0)
+        act = str(cm.exception)
+        exp = r"Invalid side='BUY'"
+        self.assert_equal(act, exp, fuzzy_match=True)
+
+    def test_invalid_side3(self) -> None:
+        """
+        Check that an assertion is raised when an empty string is supplied as
+        the side value.
+        """
+        with self.assertRaises(ValueError) as cm:
+            self._calculate_price_helper("", 0.5, 0.01, 1464553467, 3, 0)
+        act = str(cm.exception)
+        exp = r"Invalid side=''"
+        self.assert_equal(act, exp, fuzzy_match=True)
+
     def _calculate_price_helper(
         self,
         side: str,

--- a/oms/limit_price_computer/test/test_limit_price_computer_using_volatility.py
+++ b/oms/limit_price_computer/test/test_limit_price_computer_using_volatility.py
@@ -337,7 +337,7 @@ class Test_limit_price_computer_using_volatility(hunitest.TestCase):
         """
         with self.assertRaises(ValueError) as cm:
             self._calculate_price_helper(
-                "non-existent-side", 0.5, 0.01, 1464553467, 3, 0
+                "non-existent-side", 0.5, 0.01, pd.Timedelta("30S"), 3, 0
             )
         act = str(cm.exception)
         exp = r"Invalid side='non-existent-side'"

--- a/oms/limit_price_computer/test/test_limit_price_computer_using_volatility.py
+++ b/oms/limit_price_computer/test/test_limit_price_computer_using_volatility.py
@@ -330,6 +330,45 @@ class Test_limit_price_computer_using_volatility(hunitest.TestCase):
         """
         self.assert_equal(actual, expected, fuzzy_match=True)
 
+    def test_invalid_side1(self) -> None:
+        """
+        Check that an assertion is raised when a non-existent side value is
+        supplied.
+        """
+        with self.assertRaises(ValueError) as cm:
+            self._calculate_price_helper(
+                "non-existent-side", 0.5, 0.01, 1464553467, 3, 0
+            )
+        act = str(cm.exception)
+        exp = r"Invalid side='non-existent-side'"
+        self.assert_equal(act, exp, fuzzy_match=True)
+
+    def test_invalid_side2(self) -> None:
+        """
+        Check that an assertion is raised when a side value is supplied in the
+        wrong case.
+        """
+        with self.assertRaises(ValueError) as cm:
+            self._calculate_price_helper(
+                "BUY", 0.5, 1464553467, 3, pd.Timedelta("30S"), 0
+            )
+        act = str(cm.exception)
+        exp = r"Invalid side='BUY'"
+        self.assert_equal(act, exp, fuzzy_match=True)
+
+    def test_invalid_side3(self) -> None:
+        """
+        Check that an assertion is raised when an empty string is supplied as
+        the side value.
+        """
+        with self.assertRaises(ValueError) as cm:
+            self._calculate_price_helper(
+                "", 0.5, 1464553467, 3, pd.Timedelta("30S"), 0
+            )
+        act = str(cm.exception)
+        exp = r"Invalid side=''"
+        self.assert_equal(act, exp, fuzzy_match=True)
+
     def _calculate_price_helper(
         self,
         side: str,


### PR DESCRIPTION
Task [#1037](https://github.com/kaizen-ai/kaizenflow/issues/1037)

Add the following test cases for handling invalid side values in limit price calcution:
-  a non-existent side value is supplied
-  a side value is supplied in the wrong case
-  an empty string is supplied as the side value