### PR TITLE
Add Unit test for Master_system_run_debugger

### DIFF
--- a/oms/execution_analysis_configs.py
+++ b/oms/execution_analysis_configs.py
@@ -8,6 +8,9 @@ import oms.execution_analysis_configs as oexancon
 
 import logging
 import os
+from typing import List
+
+import pandas as pd
 
 import core.config as cconfig
 import helpers.hdatetime as hdateti
@@ -320,6 +323,56 @@ def get_master_trading_system_report_notebook_config(
     config_dict = {
         "timestamp_dir": timestamp_dir,
         "analysis_notebooks_file_path": analysis_notebooks_file_path,
+    }
+    config = cconfig.Config.from_dict(config_dict)
+    config_list = cconfig.ConfigList([config])
+    return config_list
+
+
+# #############################################################################
+# Master_system_run_debugger
+# #############################################################################
+
+
+def build_master_system_run_debugger_configs(
+    dst_root_dir: str,
+    dag_builder_name: str,
+    run_mode: str,
+    start_timestamp_as_str: str,
+    end_timestamp_as_str: str,
+    mode: str,
+    node_name: str,
+    bar_timestamp: str,
+    asset_id: int,
+    *,
+    columns: List[str] = ["close", "feature"],
+) -> cconfig.ConfigList:
+    """
+    Build config for `Master_system_run_debugger` notebook.
+
+    :param dst_root_dir: root directory for the destination
+    :param dag_builder_name: e.g., "C5b"
+    :param run_mode: e.g., "paper_trading"
+    :param start_timestamp_as_str: e.g., "20230713_131000"
+    :param end_timestamp_as_str: e.g., "20230714_130500"
+    :param mode: mode of the operation, e.g., "scheduled"
+    :param node_name: e.g., "predict.9.process_forecasts"
+    :param bar_timestamp: as pd.Timestamp-compatible string, e.g., "2023-07-13 10:20:00-04:00"
+    :param asset_id: e.g., 2484635488
+    :param columns: list of column names (e.g., ["close", "feature"])
+    :return: list of configs with a single resulting config
+    """
+    config_dict = {
+        "dst_root_dir": dst_root_dir,
+        "dag_builder_name": dag_builder_name,
+        "run_mode": run_mode,
+        "start_timestamp_as_str": start_timestamp_as_str,
+        "end_timestamp_as_str": end_timestamp_as_str,
+        "mode": mode,
+        "node_name": node_name,
+        "bar_timestamp": pd.Timestamp(bar_timestamp),
+        "asset_id": asset_id,
+        "columns": columns,
     }
     config = cconfig.Config.from_dict(config_dict)
     config_list = cconfig.ConfigList([config])

--- a/oms/test/test_notebooks.py
+++ b/oms/test/test_notebooks.py
@@ -118,6 +118,35 @@ def build_test_broker_portfolio_reconciliation_config(
     return config_list
 
 
+def build_test_master_system_run_debugger_configs() -> cconfig.ConfigList:
+    """
+    Default config builder for testing the Master_system_run_debugger notebook
+    """
+    dst_root_dir = "/shared_data/ecs/preprod/system_reconciliation"
+    dag_builder_name = "C5b"
+    run_mode = "paper_trading"
+    start_timestamp_as_str = "20230713_131000"
+    end_timestamp_as_str = "20230714_130500"
+    mode = "scheduled"
+    node_name = "predict.9.process_forecasts"
+    bar_timestamp = "2023-07-13 10:20:00-04:00"
+    asset_id = 2484635488
+    columns = ["close", "feature"]
+
+    return oexancon.build_master_system_run_debugger_configs(
+        dst_root_dir,
+        dag_builder_name,
+        run_mode,
+        start_timestamp_as_str,
+        end_timestamp_as_str,
+        mode,
+        node_name,
+        bar_timestamp,
+        asset_id,
+        columns=columns,
+    )
+
+
 class Test_run_master_notebooks(dsnrn.Test_Run_Notebook_TestCase):
     @pytest.mark.superslow("~125 seconds.")
     @pytest.mark.skipif(
@@ -143,6 +172,17 @@ class Test_run_master_notebooks(dsnrn.Test_Run_Notebook_TestCase):
         notebook_path = "oms/notebooks/Master_broker_debugging.ipynb"
         config_builder = (
             "oms.test.test_notebooks.build_test_broker_debugging_config"
+        )
+        self._run_notebook(notebook_path, config_builder)
+
+    @pytest.mark.superslow("~50 seconds.")
+    def test_run_master_system_run_debugger(self) -> None:
+        """
+        Run `oms/notebooks/Master_system_run_debugger.ipynb` notebook end-to-end.
+        """
+        notebook_path = "oms/notebooks/Master_system_run_debugger.ipynb"
+        config_builder = (
+            "oms.test.test_notebooks.build_test_master_system_run_debugger_configs"
         )
         self._run_notebook(notebook_path, config_builder)
 


### PR DESCRIPTION
Task https://github.com/kaizen-ai/kaizenflow/issues/1032

Add Unit test for `oms/notebooks/Master_system_run_debugger.ipynb` to `Test_run_master_notebooks` located at `oms/test/test_notebooks.py`
- Create a config builder function at `oms/execution_analysis_configs.py`
- Create a corresponding test method at Test_run_master_notebooks